### PR TITLE
Send FCM notifications on configured statuses exceed & Refactor persistence

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::net::SocketAddr;
 
 mod api;
 mod notification_service;
+pub mod persistence;
 
 use env_logger;
 use log::{error, info};
@@ -101,6 +102,14 @@ async fn main() {
         Some(addr) => addr,
         None => {
             error!("Failed to get local IP address.");
+            return;
+        }
+    };
+
+    match crate::persistence::init_db().await {
+        Ok(val) => val,
+        Err(e) => {
+            error!("Database initialization failed: {:?}", e);
             return;
         }
     };

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -9,14 +9,6 @@ pub mod persistence;
 pub mod system_monitor;
 
 pub async fn init() -> Result<(), ()> {
-    match persistence::init_db().await {
-        Ok(val) => val,
-        Err(e) => {
-            debug!("Database initialization failed: {:?}", e);
-            return Err(());
-        }
-    };
-
     let monitor = system_monitor::SystemMonitor::new();
     monitor.start_monitoring().await;
     debug!("System monitor started");

--- a/src/monitor/config_exceeds.rs
+++ b/src/monitor/config_exceeds.rs
@@ -162,6 +162,10 @@ async fn send_notification_to_exceeding_device(
         body: body.to_string(),
     };
     let fcm_token = config.fcm_token.to_string();
+
+    // TODO(adnanjpg): currently the notifications are sent silently
+    // this has to have a higher priority
+    // add a priority field to the send_notification_to_single function
     let not_res = notification_service::send_notification_to_single(
         &config.device_id,
         &fcm_token,

--- a/src/monitor/persistence.rs
+++ b/src/monitor/persistence.rs
@@ -1,6 +1,4 @@
-use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
-use sqlx::{ConnectOptions, SqliteConnection};
-use std::str::FromStr;
+use sqlx::SqliteConnection;
 
 mod monitor_config;
 use self::monitor_config::create_monitor_configs_table;
@@ -30,53 +28,23 @@ mod status_mem;
 use self::status_mem::{create_mem_status_frame_singles_table, create_mem_status_frames_table};
 pub use self::status_mem::{get_mem_status_between_dates, insert_mem_status_frame};
 
-const SQLITE_DBS_FOLDER_PATH: &str = "./db";
-const SQLITE_DB_PATH: &str = "./db/monitor.sqlite3";
-const SQLITE_DB_CONN_STR: &str = "sqlite:./db/monitor.sqlite3";
+pub use crate::persistence::{get_default_sql_connection, get_sql_connection, FetchId};
 
-#[derive(Debug, sqlx::FromRow)]
-struct FetchId {
-    pub id: i64,
-}
+pub async fn init_db(conn: &mut SqliteConnection) -> Result<(), sqlx::Error> {
+    create_monitor_configs_table(conn).await?;
 
-async fn get_sql_connection(db_path: &str) -> Result<SqliteConnection, sqlx::Error> {
-    let conn = SqliteConnectOptions::from_str(db_path)
-        .unwrap()
-        .journal_mode(SqliteJournalMode::Wal)
-        .connect()
-        .await?;
+    create_hardware_cpu_infos_table(conn).await?;
+    create_hardware_disk_infos_table(conn).await?;
+    create_hardware_mem_infos_table(conn).await?;
 
-    Ok(conn)
-}
+    create_cpu_status_frames_table(conn).await?;
+    create_cpu_status_frame_cores_table(conn).await?;
 
-pub async fn init_db() -> Result<(), sqlx::Error> {
-    // check if db folder exists
-    if !std::path::Path::new(SQLITE_DBS_FOLDER_PATH).exists() {
-        // create db folder
-        std::fs::create_dir(SQLITE_DBS_FOLDER_PATH).unwrap();
-    }
-    // if db file not exists, create it
-    if !std::path::Path::new(SQLITE_DB_PATH).exists() {
-        // create db file
-        std::fs::File::create(SQLITE_DB_PATH).unwrap();
-    }
+    create_disk_status_frames_table(conn).await?;
+    create_disk_status_frame_singles_table(conn).await?;
 
-    let mut conn = get_sql_connection(SQLITE_DB_CONN_STR).await?;
-
-    create_monitor_configs_table(&mut conn).await?;
-
-    create_hardware_cpu_infos_table(&mut conn).await?;
-    create_hardware_disk_infos_table(&mut conn).await?;
-    create_hardware_mem_infos_table(&mut conn).await?;
-
-    create_cpu_status_frames_table(&mut conn).await?;
-    create_cpu_status_frame_cores_table(&mut conn).await?;
-
-    create_disk_status_frames_table(&mut conn).await?;
-    create_disk_status_frame_singles_table(&mut conn).await?;
-
-    create_mem_status_frames_table(&mut conn).await?;
-    create_mem_status_frame_singles_table(&mut conn).await?;
+    create_mem_status_frames_table(conn).await?;
+    create_mem_status_frame_singles_table(conn).await?;
 
     Ok(())
 }

--- a/src/monitor/persistence/hardware_cpu_info.rs
+++ b/src/monitor/persistence/hardware_cpu_info.rs
@@ -2,12 +2,12 @@ use sqlx::SqliteConnection;
 
 use crate::monitor::models::get_hardware_info::HardwareCpuInfo;
 
-use super::{get_sql_connection, FetchId, SQLITE_DB_CONN_STR};
+use super::{get_default_sql_connection, FetchId};
 
 const HARDWARE_CPU_INFOS_TABLE_NAME: &str = "cpu_infos";
 
 pub(super) async fn insert_hardware_cpu_info(info: &HardwareCpuInfo) -> Result<(), sqlx::Error> {
-    let mut conn = get_sql_connection(SQLITE_DB_CONN_STR).await?;
+    let mut conn = get_default_sql_connection().await?;
 
     // check if a record with the same cpu_id already exists
     let exists_record_check = format!(
@@ -58,7 +58,7 @@ pub(super) async fn insert_hardware_cpu_info(info: &HardwareCpuInfo) -> Result<(
 }
 
 pub(super) async fn fetch_latest_hardware_cpus_info() -> Result<Vec<HardwareCpuInfo>, sqlx::Error> {
-    let mut conn = get_sql_connection(SQLITE_DB_CONN_STR).await?;
+    let mut conn = get_default_sql_connection().await?;
 
     let statement = format!(
         "

--- a/src/monitor/persistence/hardware_disk_info.rs
+++ b/src/monitor/persistence/hardware_disk_info.rs
@@ -2,12 +2,12 @@ use sqlx::SqliteConnection;
 
 use crate::monitor::models::get_hardware_info::HardwareDiskInfo;
 
-use super::{get_sql_connection, FetchId, SQLITE_DB_CONN_STR};
+use super::{get_default_sql_connection, FetchId};
 
 const HARDWARE_DISK_INFOS_TABLE_NAME: &str = "disk_infos";
 
 pub(super) async fn insert_hardware_disk_info(info: &HardwareDiskInfo) -> Result<(), sqlx::Error> {
-    let mut conn = get_sql_connection(SQLITE_DB_CONN_STR).await?;
+    let mut conn = get_default_sql_connection().await?;
 
     // check if a record with the same cpu_id already exists
     let exists_record_check = format!(
@@ -60,7 +60,7 @@ pub(super) async fn insert_hardware_disk_info(info: &HardwareDiskInfo) -> Result
 
 pub(super) async fn fetch_latest_hardware_disks_info() -> Result<Vec<HardwareDiskInfo>, sqlx::Error>
 {
-    let mut conn = get_sql_connection(SQLITE_DB_CONN_STR).await?;
+    let mut conn = get_default_sql_connection().await?;
 
     // get all with distinct disk_id
     let statement = format!(

--- a/src/monitor/persistence/hardware_mem_info.rs
+++ b/src/monitor/persistence/hardware_mem_info.rs
@@ -2,12 +2,12 @@ use sqlx::SqliteConnection;
 
 use crate::monitor::models::get_hardware_info::HardwareMemInfo;
 
-use super::{get_sql_connection, FetchId, SQLITE_DB_CONN_STR};
+use super::{get_default_sql_connection, FetchId};
 
 const HARDWARE_MEM_INFOS_TABLE_NAME: &str = "mem_infos";
 
 pub(super) async fn insert_hardware_mem_info(info: &HardwareMemInfo) -> Result<(), sqlx::Error> {
-    let mut conn = get_sql_connection(SQLITE_DB_CONN_STR).await?;
+    let mut conn = get_default_sql_connection().await?;
 
     // check if a record with the same cpu_id already exists
     let exists_record_check = format!(
@@ -54,7 +54,7 @@ pub(super) async fn insert_hardware_mem_info(info: &HardwareMemInfo) -> Result<(
 }
 
 pub(super) async fn fetch_latest_hardware_mems_info() -> Result<Vec<HardwareMemInfo>, sqlx::Error> {
-    let mut conn = get_sql_connection(SQLITE_DB_CONN_STR).await?;
+    let mut conn = get_default_sql_connection().await?;
 
     // get all with distinct mem_id
     let statement = format!(

--- a/src/monitor/persistence/monitor_config.rs
+++ b/src/monitor/persistence/monitor_config.rs
@@ -2,7 +2,7 @@ use sqlx::SqliteConnection;
 
 use crate::monitor::models::MonitorConfig;
 
-use super::{get_sql_connection, FetchId, SQLITE_DB_CONN_STR};
+use super::{get_default_sql_connection, FetchId};
 
 const MONITOR_CONFIGS_TABLE_NAME: &str = "configs";
 
@@ -10,7 +10,7 @@ pub async fn insert_or_update_monitor_config(
     config: &MonitorConfig,
     device_id: &str,
 ) -> Result<(), sqlx::Error> {
-    let mut conn = get_sql_connection(SQLITE_DB_CONN_STR).await?;
+    let mut conn = get_default_sql_connection().await?;
 
     // check if a record with the same device_id already exists
     let exists_record_check = format!(
@@ -70,7 +70,7 @@ pub async fn insert_or_update_monitor_config(
 }
 
 pub async fn fetch_monitor_configs() -> Result<Vec<MonitorConfig>, sqlx::Error> {
-    let mut conn = get_sql_connection(SQLITE_DB_CONN_STR).await?;
+    let mut conn = get_default_sql_connection().await?;
 
     let statement = format!("SELECT * FROM {}", MONITOR_CONFIGS_TABLE_NAME);
     let configs = sqlx::query_as::<_, MonitorConfig>(&statement)

--- a/src/monitor/persistence/status_cpu.rs
+++ b/src/monitor/persistence/status_cpu.rs
@@ -2,13 +2,13 @@ use sqlx::SqliteConnection;
 
 use crate::monitor::models::get_cpu_status::{CpuCoreInfo, CpuFrameStatus};
 
-use super::{get_sql_connection, FetchId, SQLITE_DB_CONN_STR};
+use super::{get_default_sql_connection, FetchId};
 
 const CPU_STATUS_FRAME_TABLE_NAME: &str = "cpu_status_frame";
 const CPU_STATUS_FRAME_CORE_TABLE_NAME: &str = "cpu_status_frame_core";
 
 pub async fn insert_cpu_status_frame(status: &CpuFrameStatus) -> Result<(), sqlx::Error> {
-    let mut conn = get_sql_connection(SQLITE_DB_CONN_STR).await?;
+    let mut conn = get_default_sql_connection().await?;
 
     let statement = format!(
         "INSERT INTO {} 
@@ -36,7 +36,7 @@ pub async fn insert_cpu_status_frame(status: &CpuFrameStatus) -> Result<(), sqlx
 }
 
 async fn insert_cpu_status_frame_core(status: &CpuCoreInfo) -> Result<(), sqlx::Error> {
-    let mut conn = get_sql_connection(SQLITE_DB_CONN_STR).await?;
+    let mut conn = get_default_sql_connection().await?;
 
     let statement = format!(
         "INSERT INTO {} (frame_id, cpu_id, freq, usage) VALUES (?, ?, ?, ?)",
@@ -57,7 +57,7 @@ pub async fn get_cpu_status_between_dates(
     start_date: i64,
     end_date: i64,
 ) -> Result<Vec<CpuFrameStatus>, sqlx::Error> {
-    let mut conn = get_sql_connection(SQLITE_DB_CONN_STR).await?;
+    let mut conn = get_default_sql_connection().await?;
 
     let frames_statement = format!(
         "SELECT id, last_check FROM {} WHERE last_check BETWEEN ? AND ?",

--- a/src/monitor/persistence/status_disk.rs
+++ b/src/monitor/persistence/status_disk.rs
@@ -2,13 +2,13 @@ use sqlx::SqliteConnection;
 
 use crate::monitor::models::get_disk_status::{DiskFrameStatus, SingleDiskInfo};
 
-use super::{get_sql_connection, FetchId, SQLITE_DB_CONN_STR};
+use super::{get_default_sql_connection, FetchId};
 
 const DISK_STATUS_FRAME_TABLE_NAME: &str = "disk_status_frame";
 const DISK_STATUS_FRAME_SINGLE_TABLE_NAME: &str = "disk_status_frame_single";
 
 pub async fn insert_disk_status_frame(status: &DiskFrameStatus) -> Result<(), sqlx::Error> {
-    let mut conn = get_sql_connection(SQLITE_DB_CONN_STR).await?;
+    let mut conn = get_default_sql_connection().await?;
 
     let statement = format!(
         "INSERT INTO {} 
@@ -36,7 +36,7 @@ pub async fn insert_disk_status_frame(status: &DiskFrameStatus) -> Result<(), sq
 }
 
 async fn insert_disk_status_frame_single(status: &SingleDiskInfo) -> Result<(), sqlx::Error> {
-    let mut conn = get_sql_connection(SQLITE_DB_CONN_STR).await?;
+    let mut conn = get_default_sql_connection().await?;
 
     let statement = format!(
         "INSERT INTO {} (frame_id, disk_id, available) VALUES (?, ?, ?)",
@@ -56,7 +56,7 @@ pub async fn get_disk_status_between_dates(
     start_date: i64,
     end_date: i64,
 ) -> Result<Vec<DiskFrameStatus>, sqlx::Error> {
-    let mut conn = get_sql_connection(SQLITE_DB_CONN_STR).await?;
+    let mut conn = get_default_sql_connection().await?;
 
     let frames_statement = format!(
         "SELECT id, last_check FROM {} WHERE last_check BETWEEN ? AND ?",

--- a/src/monitor/persistence/status_mem.rs
+++ b/src/monitor/persistence/status_mem.rs
@@ -2,13 +2,13 @@ use sqlx::SqliteConnection;
 
 use crate::monitor::models::get_mem_status::{MemFrameStatus, SingleMemInfo};
 
-use super::{get_sql_connection, FetchId, SQLITE_DB_CONN_STR};
+use super::{get_default_sql_connection, FetchId};
 
 const MEM_STATUS_FRAME_TABLE_NAME: &str = "mem_status_frame";
 const MEM_STATUS_FRAME_SINGLE_TABLE_NAME: &str = "mem_status_frame_single";
 
 pub async fn insert_mem_status_frame(status: &MemFrameStatus) -> Result<(), sqlx::Error> {
-    let mut conn = get_sql_connection(SQLITE_DB_CONN_STR).await?;
+    let mut conn = get_default_sql_connection().await?;
 
     let statement = format!(
         "INSERT INTO {} 
@@ -36,7 +36,7 @@ pub async fn insert_mem_status_frame(status: &MemFrameStatus) -> Result<(), sqlx
 }
 
 async fn insert_mem_status_frame_single(status: &SingleMemInfo) -> Result<(), sqlx::Error> {
-    let mut conn = get_sql_connection(SQLITE_DB_CONN_STR).await?;
+    let mut conn = get_default_sql_connection().await?;
 
     let statement = format!(
         "INSERT INTO {} (frame_id, mem_id, available) VALUES (?, ?, ?)",
@@ -56,7 +56,7 @@ pub async fn get_mem_status_between_dates(
     start_date: i64,
     end_date: i64,
 ) -> Result<Vec<MemFrameStatus>, sqlx::Error> {
-    let mut conn = get_sql_connection(SQLITE_DB_CONN_STR).await?;
+    let mut conn = get_default_sql_connection().await?;
 
     let frames_statement = format!(
         "SELECT id, last_check FROM {} WHERE last_check BETWEEN ? AND ?",

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -2,6 +2,8 @@ use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
 use sqlx::{ConnectOptions, SqliteConnection};
 use std::str::FromStr;
 
+pub mod notification_logs;
+
 const SQLITE_DBS_FOLDER_PATH: &str = "./db";
 const SQLITE_DB_PATH: &str = "./db/monitor.sqlite3";
 const SQLITE_DB_CONN_STR: &str = "sqlite:./db/monitor.sqlite3";
@@ -39,6 +41,8 @@ pub async fn init_db() -> Result<(), sqlx::Error> {
     let mut conn = get_sql_connection(SQLITE_DB_CONN_STR).await?;
 
     crate::monitor::persistence::init_db(&mut conn).await?;
+
+    notification_logs::create_notification_logs_table(&mut conn).await?;
 
     Ok(())
 }

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -1,0 +1,44 @@
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
+use sqlx::{ConnectOptions, SqliteConnection};
+use std::str::FromStr;
+
+const SQLITE_DBS_FOLDER_PATH: &str = "./db";
+const SQLITE_DB_PATH: &str = "./db/monitor.sqlite3";
+const SQLITE_DB_CONN_STR: &str = "sqlite:./db/monitor.sqlite3";
+
+#[derive(Debug, sqlx::FromRow)]
+pub struct FetchId {
+    pub id: i64,
+}
+
+pub async fn get_default_sql_connection() -> Result<SqliteConnection, sqlx::Error> {
+    get_sql_connection(SQLITE_DB_CONN_STR).await
+}
+pub async fn get_sql_connection(db_path: &str) -> Result<SqliteConnection, sqlx::Error> {
+    let conn = SqliteConnectOptions::from_str(db_path)
+        .unwrap()
+        .journal_mode(SqliteJournalMode::Wal)
+        .connect()
+        .await?;
+
+    Ok(conn)
+}
+
+pub async fn init_db() -> Result<(), sqlx::Error> {
+    // check if db folder exists
+    if !std::path::Path::new(SQLITE_DBS_FOLDER_PATH).exists() {
+        // create db folder
+        std::fs::create_dir(SQLITE_DBS_FOLDER_PATH).unwrap();
+    }
+    // if db file not exists, create it
+    if !std::path::Path::new(SQLITE_DB_PATH).exists() {
+        // create db file
+        std::fs::File::create(SQLITE_DB_PATH).unwrap();
+    }
+
+    let mut conn = get_sql_connection(SQLITE_DB_CONN_STR).await?;
+
+    crate::monitor::persistence::init_db(&mut conn).await?;
+
+    Ok(())
+}

--- a/src/persistence/notification_logs.rs
+++ b/src/persistence/notification_logs.rs
@@ -1,0 +1,82 @@
+use sqlx::SqliteConnection;
+
+use super::get_default_sql_connection;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, sqlx::Type)]
+#[serde(rename_all = "lowercase")]
+pub enum NotificationType {
+    StatusLimitsExceeding,
+}
+
+#[derive(Debug, Serialize, Deserialize, sqlx::FromRow)]
+pub struct NotificationLog {
+    pub id: i64,
+    pub notification_type: NotificationType,
+    pub device_id: String,
+    pub sent_at: i64,
+}
+
+const NOTIFICATION_LOGS_TABLE_NAME: &str = "cpu_infos";
+
+pub(super) async fn insert_notification_log(log: &NotificationLog) -> Result<(), sqlx::Error> {
+    let mut conn = get_default_sql_connection().await?;
+
+    let statement = format!(
+        "INSERT INTO {} 
+        (notification_type, device_id, sent_at) 
+        VALUES (?, ?, ?)",
+        NOTIFICATION_LOGS_TABLE_NAME
+    );
+
+    sqlx::query(&statement)
+        .bind(&log.notification_type)
+        .bind(&log.device_id)
+        .bind(&log.sent_at)
+        .execute(&mut conn)
+        .await?;
+
+    Ok(())
+}
+
+pub(super) async fn fetch_latest_for_device_id_and_type(
+    device_id: &str,
+    notification_type: &NotificationType,
+) -> Result<Vec<NotificationLog>, sqlx::Error> {
+    let mut conn = get_default_sql_connection().await?;
+
+    let statement = format!(
+        "
+        SELECT *
+        FROM {}
+        WHERE device_id = ?
+        AND notification_type = ?
+        ",
+        NOTIFICATION_LOGS_TABLE_NAME
+    );
+    let info = sqlx::query_as::<_, NotificationLog>(&statement)
+        .bind(&device_id)
+        .bind(&notification_type)
+        .fetch_all(&mut conn)
+        .await?;
+
+    Ok(info)
+}
+
+pub(super) async fn create_notification_logs_table(
+    conn: &mut SqliteConnection,
+) -> Result<(), sqlx::Error> {
+    let statement = format!(
+        "CREATE TABLE IF NOT EXISTS {} (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        notification_type INTEGER NOT NULL,
+        device_id TEXT NOT NULL,
+        sent_at INTEGER NOT NULL
+    )",
+        NOTIFICATION_LOGS_TABLE_NAME
+    );
+
+    sqlx::query(&statement).execute(conn).await?;
+
+    Ok(())
+}

--- a/src/persistence/notification_logs.rs
+++ b/src/persistence/notification_logs.rs
@@ -1,4 +1,3 @@
-use log::debug;
 use sqlx::SqliteConnection;
 
 use super::get_default_sql_connection;


### PR DESCRIPTION
- added a top level persistence module
- added `notification_logs` table
- added a function that triggers an FCM notification when any of the configured statuses exceed